### PR TITLE
Send file name and line number when sending selection to slack

### DIFF
--- a/Slack.py
+++ b/Slack.py
@@ -242,16 +242,26 @@ class SendSelectionCommand(BaseSend):
     """ Send the selected text to slack. Multiple selections supported """
     def run(self, view):
         super(SendSelectionCommand, self).run(view)
+        fileName = self.friendly_filename()
         # get all selected regions
         for region in self.view.sel():
             text = self.view.substr(region)
+            (lineFrom,colFrom) = self.view.rowcol(region.begin())
+            (lineTo,colTo) = self.view.rowcol(region.end())
 
             if not text:
                 sublime.error_message("SLACK Error: No text selected")
                 return
-            self.messages.append("```{0}```".format(text))
+            self.messages.append(">*File: {0}, Line(s): {1}-{2}*```{3}```".format(fileName,lineFrom,lineTo,text))
 
         threading.Thread(target=self.init_message_send).start()
+
+    def friendly_filename(self):
+        filename = self.view.file_name().split('/').pop()
+        if self.settings.get('repeat_file_ext') and len(filename.split('.')) > 1:
+            filename += '.' + filename.split('.').pop()
+        return filename
+
 
 
 class SendMessageCommand(BaseSend):

--- a/Slack.py
+++ b/Slack.py
@@ -243,17 +243,27 @@ class SendSelectionCommand(BaseSend):
     def run(self, view):
         super(SendSelectionCommand, self).run(view)
         fileName = self.friendly_filename()
+        message = ""
         # get all selected regions
         for region in self.view.sel():
             text = self.view.substr(region)
-            (lineFrom,colFrom) = self.view.rowcol(region.begin())
-            (lineTo,colTo) = self.view.rowcol(region.end())
 
             if not text:
                 sublime.error_message("SLACK Error: No text selected")
                 return
-            self.messages.append(">*File: {0}, Line(s): {1}-{2}*```{3}```".format(fileName,lineFrom,lineTo,text))
 
+            (lineFrom,colFrom) = self.view.rowcol(region.begin())
+            (lineTo,colTo) = self.view.rowcol(region.end())
+
+            if (lineTo != lineFrom and colTo == 0):
+                lineTo = lineTo-1;
+
+            if (lineFrom == lineTo):
+                message += ">*File: {0}, Line: {1}*```{2}```\n".format(fileName,lineFrom,text)
+            else:
+                message += ">*File: {0}, Line(s): {1}-{2}*```{3}```\n".format(fileName,lineFrom,lineTo,text)
+
+        self.messages.append(message)
         threading.Thread(target=self.init_message_send).start()
 
     def friendly_filename(self):


### PR DESCRIPTION
I modified python.py to include the filename and line(s) number(s) of the shared text sent through "Slack: send selection". See attached screenshot for a sample of how it looks like. I've mimicked the style of SlackStorm.
![capture d ecran 2016-05-02 a 19 31 06](https://cloud.githubusercontent.com/assets/18481454/14961976/d914fc30-109c-11e6-8004-4ad9dcb304e0.png)

